### PR TITLE
Fixes deprecation of the binary mode of np.fromstring -> np.frombuffer and np.vstack

### DIFF
--- a/pycolab/ascii_art.py
+++ b/pycolab/ascii_art.py
@@ -315,7 +315,8 @@ def ascii_art_to_uint8_nparray(art):
       'the argument to ascii_art_to_uint8_nparray must be a list (or tuple) '
       'of strings containing the same number of strictly-ASCII characters.')
   try:
-    art = np.vstack(np.fromstring(line, dtype=np.uint8) for line in art)
+    art = np.vstack([np.frombuffer(line.encode('ascii'), dtype=np.uint8) 
+                     for line in art])
   except ValueError as e:
     raise ValueError('{} (original error from numpy: {})'.format(error_text, e))
   except TypeError as e:


### PR DESCRIPTION
This PR fixes the `DepreciationWarning` outbreak of `numpy` of version `1.16` (only tested on this version) when `ascii_art` was called repeatedly. This also enforces the line to be `ascii` encoded as in the comment:

> 'strings containing [...] strictly-ASCII characters.'

which is safely encoded into `np.frombuffer`.

Coincidentally, there exists another `DepreciationWarning` on the same line with the use of `np.vstack` and an iterable that is not a `list` or `tuple` (for example). By wrapping the iterable as a `list`, this accomplishes just one possible alternative.

